### PR TITLE
Release version 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,8 @@ rust-version = "1.64.0"
 [dependencies]
 bitflags = "2.0"
 cursor-icon = "1.0.0"
-wayland-backend = { version = ">=0.1.0, <0.3.0", default-features = false }
+wayland-backend_0_1 = { package = "wayland-backend", version = "0.1.0", default-features = false, optional = true }
+wayland-backend_0_2 = { package = "wayland-backend", version = "0.2.0", default-features = false, optional = true }
+
+[features]
+default = ["wayland-backend_0_2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-csd-frame"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Kirill Chibisov <contact@kchibisov.com>"]
 repository = "https://github.com/rust-windowing/wayland-csd-frame"
 description = "Common trait and types for wayland CSD interop"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,14 @@
 use std::num::NonZeroU32;
 use std::time::Duration;
 
+#[cfg(not(any(feature = "wayland-backend_0_1", feature = "wayland-backend_0_2")))]
+compile_error!("Ether wayland-backend_0_1 or wayland-backend_0_2 feature must be enabled");
+
 use bitflags::bitflags;
-use wayland_backend::client::ObjectId;
+#[cfg(feature = "wayland-backend_0_1")]
+use wayland_backend_0_1::client::ObjectId;
+#[cfg(feature = "wayland-backend_0_2")]
+use wayland_backend_0_2::client::ObjectId;
 
 #[doc(inline)]
 pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};


### PR DESCRIPTION
--

Cargo dependency resolution is pretty bad and can't work without a lock file around to handle such dependency version we have in 0.2.2.