### PR TITLE
Add a feature for `wayland_backend_0_3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,4 @@ rust-version = "1.64.0"
 [dependencies]
 bitflags = "2.0"
 cursor-icon = "1.0.0"
-wayland-backend_0_1 = { package = "wayland-backend", version = "0.1.0", default-features = false, optional = true }
-wayland-backend_0_2 = { package = "wayland-backend", version = "0.2.0", default-features = false, optional = true }
-
-[features]
-default = ["wayland-backend_0_2"]
+wayland-backend = { version = "0.3.0", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,8 @@
 use std::num::NonZeroU32;
 use std::time::Duration;
 
-#[cfg(not(any(feature = "wayland-backend_0_1", feature = "wayland-backend_0_2")))]
-compile_error!("Ether wayland-backend_0_1 or wayland-backend_0_2 feature must be enabled");
-
 use bitflags::bitflags;
-#[cfg(feature = "wayland-backend_0_1")]
-use wayland_backend_0_1::client::ObjectId;
-#[cfg(feature = "wayland-backend_0_2")]
-use wayland_backend_0_2::client::ObjectId;
+use wayland_backend::client::ObjectId;
 
 #[doc(inline)]
 pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};


### PR DESCRIPTION
Using features like this is problematic if more the crate is pulled in with different versions in different crates. Hopefully not too much of an issue for this particular crate...

Anyway, not hard to add a new version here.