### PR TITLE
Use `doc_cfg` feature instead of `doc_auto_cfg` on `docsrs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![cfg_attr(clippy, deny(warnings))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-
 //! The interface for wayland client side decorations (CSD).
 //!
 //! The crate is intended to be used by libraries providing client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 #![cfg_attr(feature = "cargo-clippy", deny(warnings))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! The interface for wayland client side decorations (CSD).
 //!


### PR DESCRIPTION
Fixes build with recent nightly, as now used by docs.rs.

Can be tested with `RUSTDOCFLAGS=--cfg=docsrs cargo +nightly doc --all-features`, with these patches:

```toml
[patch.crates-io]
cursor-icon = { git = "https://github.com/rust-windowing/cursor-icon" }
wayland-client = { git = "https://github.com/smithay/wayland-rs" }
wayland-backend = { git = "https://github.com/smithay/wayland-rs" }
```